### PR TITLE
Twig syntax correction in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Twital and Twig syntax to use the Twig ``autoescape`` tag.
 <h1 t:if="users">
     {% spaceless %}
         Members
-    {% spaceless %}
+    {% endspaceless %}
 </h1>
 ```
 


### PR DESCRIPTION
Hi!

Thanks for sharing this amazing project.

There seems to be a problem with the twig syntax in the README file.

Cheers,
Thomas.
