### PR TITLE
Fixed a full compatibility mode

### DIFF
--- a/src/Goetas/Twital/EventSubscriber/AbstractTwigExpressionSubscriber.php
+++ b/src/Goetas/Twital/EventSubscriber/AbstractTwigExpressionSubscriber.php
@@ -13,7 +13,6 @@ abstract class AbstractTwigExpressionSubscriber implements EventSubscriberInterf
     const REGEX_STRING  = '"[^"\\\\]*(?:\\\\.[^"\\\\]*)*"|\'[^\'\\\\]*(?:\\\\.[^\'\\\\]*)*\'';
 
     protected $placeholderFormat = '';
-
     protected $regexes = array();
 
     public function __construct(array $placeholder = array('[_TWITAL_[', ']_TWITAL_]'), array $options = array())
@@ -27,12 +26,46 @@ abstract class AbstractTwigExpressionSubscriber implements EventSubscriberInterf
         ), $options);
 
         $this->regexes = array(
-            'twig' => '{('.preg_quote($options['tag_block'][0]).
-                '|'.preg_quote($options['tag_variable'][0]).'|'.preg_quote($options['tag_comment'][0]).
-                ')('.self::REGEX_STRING.'|[^"\']*)+('.preg_quote($options['tag_block'][1]).
-                '|'.preg_quote($options['tag_variable'][1]).'|'.preg_quote($options['tag_comment'][1]).
-                ')}siuU',
+            'twig_start' => '{('.preg_quote($options['tag_block'][0]).'|'.preg_quote($options['tag_variable'][0]).'|'.preg_quote($options['tag_comment'][0]).')}',
             'placeholder' => '{('.preg_quote($placeholder[0]).'(.+)'.preg_quote($placeholder[1]).')}siuU',
+            'twig_inner_'.$options['tag_block'][0] => '{('.self::REGEX_STRING.'|'.preg_quote($options['tag_block'][1]).'|([^"\']*?'.preg_quote($options['tag_block'][1]).')|[^"\']*)}si',
+            'twig_inner_'.$options['tag_variable'][0] => '{('.self::REGEX_STRING.'|'.preg_quote($options['tag_variable'][1]).'|([^"\']*?'.preg_quote($options['tag_variable'][1]).')|[^"\']*)}si',
+            'twig_inner_'.$options['tag_comment'][0] => '{((.*?'.preg_quote($options['tag_comment'][1]).'))}si',
         );
+    }
+
+    protected function processTwig($template, \CLosure $processor)
+    {
+        $offset = 0;
+        while (preg_match($this->regexes['twig_start'], $template, $matches, PREG_OFFSET_CAPTURE, $offset)) {
+            $twig = '';
+            $buffer = $matches[0][0];
+            $from = $matches[0][1];
+            $offset = $from + strlen($buffer);
+            $pattern = $this->regexes['twig_inner_'.$buffer];
+            while (preg_match($pattern, $template, $inners, PREG_OFFSET_CAPTURE, $offset)) {
+                $buffer .= $inners[0][0];
+                $offset += strlen($inners[0][0]);
+                if (isset($inners[2])) {
+                    $twig = $buffer;
+                    break;
+                }
+            };
+
+            if (!$twig) {
+                continue;
+            }
+
+            $replacement = $processor($twig, $template, $from);
+            $template = substr_replace($template, $replacement, $from, $offset - $from);
+            $offset = $from + strlen($replacement);
+        }
+
+        return $template;
+    }
+
+    protected function processPlaceholder($template, \Closure $processor)
+    {
+        return preg_replace_callback($this->regexes['placeholder'], $processor, $template);
     }
 }

--- a/src/Goetas/Twital/EventSubscriber/FixHtmlEntitiesInExpressionSubscriber.php
+++ b/src/Goetas/Twital/EventSubscriber/FixHtmlEntitiesInExpressionSubscriber.php
@@ -27,9 +27,9 @@ class FixHtmlEntitiesInExpressionSubscriber extends AbstractTwigExpressionSubscr
         $source = $event->getTemplate();
         $format = $this->placeholderFormat;
 
-        $source = preg_replace_callback($this->regexes['twig'], function ($matches) use ($format) {
-            return sprintf($format, htmlspecialchars($matches[0], ENT_COMPAT, 'UTF-8'));
-        }, $source);
+        $source = $this->processTwig($source, function ($twig) use ($format) {
+            return sprintf($format, htmlspecialchars($twig, ENT_COMPAT, 'UTF-8'));
+        });
 
         $event->setTemplate($source);
     }
@@ -42,9 +42,9 @@ class FixHtmlEntitiesInExpressionSubscriber extends AbstractTwigExpressionSubscr
     {
         $source = $event->getTemplate();
 
-        $source = preg_replace_callback($this->regexes['placeholder'], function($matches) {
+        $source = $this->processPlaceholder($source, function($matches) {
             return html_entity_decode($matches[2], ENT_COMPAT, 'UTF-8');
-        }, $source);
+        });
 
         $event->setTemplate($source);
     }

--- a/tests/Goetas/Twital/Tests/templates/logger.html.twig
+++ b/tests/Goetas/Twital/Tests/templates/logger.html.twig
@@ -1,0 +1,222 @@
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
+
+{% import _self as helper %}
+
+{% block toolbar %}
+    {% if collector.counterrors or collector.countdeprecations or collector.countscreams %}
+        {% set icon %}
+            {% set status_color = collector.counterrors ? 'red' : collector.countdeprecations ? 'yellow' : '' %}
+            {% set error_count = collector.counterrors + collector.countdeprecations + collector.countscreams %}
+            {{ include('@WebProfiler/Icon/logger.svg') }}
+            <span class="sf-toolbar-value">{{ error_count }}</span>
+        {% endset %}
+
+        {% set text %}
+            <div class="sf-toolbar-info-piece">
+                <b>Errors</b>
+                <span class="sf-toolbar-status sf-toolbar-status-{{ collector.counterrors ? 'red' }}">{{ collector.counterrors|default(0) }}</span>
+            </div>
+
+            <div class="sf-toolbar-info-piece">
+                <b>Deprecated Calls</b>
+                <span class="sf-toolbar-status sf-toolbar-status-{{ collector.countdeprecations ? 'yellow' }}">{{ collector.countdeprecations|default(0) }}</span>
+            </div>
+
+            <div class="sf-toolbar-info-piece">
+                <b>Silenced Errors</b>
+                <span class="sf-toolbar-status">{{ collector.countscreams|default(0) }}</span>
+            </div>
+        {% endset %}
+
+        {{ include('@WebProfiler/Profiler/toolbar_item.html.twig', { link: profiler_url, status: status_color }) }}
+    {% endif %}
+{% endblock %}
+
+{% block menu %}
+    <span class="label label-status-{{ collector.counterrors ? 'error' : collector.countdeprecations ? 'warning' }} {{ collector.logs is empty ? 'disabled' }}">
+        <span class="icon">{{ include('@WebProfiler/Icon/logger.svg') }}</span>
+        <strong>Logs</strong>
+        {% if collector.counterrors or collector.countdeprecations %}
+            <span class="count">
+                <span>{{ collector.counterrors ?: collector.countdeprecations }}</span>
+            </span>
+        {% endif %}
+    </span>
+{% endblock %}
+
+{% block panel %}
+    <h2>Log Messages</h2>
+
+    {% if collector.logs is empty %}
+        <div class="empty">
+            <p>No log messages available.</p>
+        </div>
+    {% else %}
+        {# sort collected logs in groups #}
+        {% set deprecation_logs, debug_logs, info_and_error_logs, silenced_logs = [], [], [], [] %}
+        {% for log in collector.logs %}
+            {% if log.context.level is defined and log.context.type is defined and log.context.type in [constant('E_DEPRECATED'), constant('E_USER_DEPRECATED')] %}
+                {% set deprecation_logs = deprecation_logs|merge([log]) %}
+            {% elseif log.context.scream is defined and log.context.scream == true  %}
+                {% set silenced_logs = silenced_logs|merge([log]) %}
+            {% elseif log.priorityName == 'DEBUG' %}
+                {% set debug_logs = debug_logs|merge([log]) %}
+            {% else %}
+                {% set info_and_error_logs = info_and_error_logs|merge([log]) %}
+            {% endif %}
+        {% endfor %}
+
+        <div class="sf-tabs">
+            <div class="tab">
+                <h3 class="tab-title">Info. &amp; Errors <span class="badge">{{ info_and_error_logs|length }}</span></h3>
+
+                <div class="tab-content">
+                    {% if info_and_error_logs is empty %}
+                        <div class="empty">
+                            <p>There are no log messages of this level.</p>
+                        </div>
+                    {% else %}
+                        {{ helper.render_table(info_and_error_logs, true) }}
+                    {% endif %}
+                </div>
+            </div>
+
+            <div class="tab">
+                {# 'deprecation_logs|length' is not used because deprecations are
+                now grouped and the group count doesn't match the message count #}
+                <h3 class="tab-title">Deprecations <span class="badge">{{ collector.countdeprecations|default(0) }}</span></h3>
+
+                <div class="tab-content">
+                    {% if deprecation_logs is empty %}
+                        <div class="empty">
+                            <p>There are no log messages about deprecated features.</p>
+                        </div>
+                    {% else %}
+                        {{ helper.render_table(deprecation_logs, false, true) }}
+                    {% endif %}
+                </div>
+            </div>
+
+            <div class="tab">
+                <h3 class="tab-title">Debug <span class="badge">{{ debug_logs|length }}</span></h3>
+
+                <div class="tab-content">
+                    {% if debug_logs is empty %}
+                        <div class="empty">
+                            <p>There are no log messages of this level.</p>
+                        </div>
+                    {% else %}
+                        {{ helper.render_table(debug_logs) }}
+                    {% endif %}
+                </div>
+            </div>
+
+            <div class="tab">
+                <h3 class="tab-title">Silenced Errors <span class="badge">{{ collector.countscreams|default(0) }}</span></h3>
+
+                <div class="tab-content">
+                    {% if silenced_logs is empty %}
+                        <div class="empty">
+                            <p>There are no log messages of this level.</p>
+                        </div>
+                    {% else %}
+                        {{ helper.render_table(silenced_logs) }}
+                    {% endif %}
+                </div>
+            </div>
+
+        </div>
+    {% endif %}
+{% endblock %}
+
+{% macro render_table(logs, show_level = false, is_deprecation = false) %}
+    {% import _self as helper %}
+    {% set channel_is_defined = (logs|first).channel is defined %}
+
+    <table class="logs">
+        <thead>
+            <tr>
+                <th>{{ show_level ? 'Level' : 'Time' }}</th>
+                {% if channel_is_defined %}<th>Channel</th>{% endif %}
+                <th>Message</th>
+            </tr>
+        </thead>
+
+        <tbody>
+            {% for log in logs %}
+                {% set css_class = is_deprecation ? ''
+                    : log.priorityName in ['CRITICAL', 'ERROR', 'ALERT', 'EMERGENCY'] ? 'status-error'
+                    : log.priorityName in ['NOTICE', 'WARNING'] ? 'status-warning'
+                %}
+                <tr class="{{ css_class }}">
+                    <td class="font-normal text-small">
+                        {% if show_level %}
+                            <span class="colored text-bold nowrap">{{ log.priorityName }}</span>
+                        {% endif %}
+                        <span class="text-muted nowrap newline">{{ log.timestamp|date('H:i:s') }}</span>
+                    </td>
+
+                    {% if channel_is_defined %}
+                        <td class="font-normal text-small text-bold nowrap">{{ log.channel }}</td>
+                    {% endif %}
+
+                    <td class="font-normal">{{ helper.render_log_message(loop.index, log, is_deprecation) }}</td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+{% endmacro %}
+
+{% macro render_log_message(log_index, log, is_deprecation = false) %}
+    {{ log.message }}
+
+    {% if is_deprecation %}
+        {% set stack = log.context.stack|default([]) %}
+        {% set id = 'sf-call-stack-' ~ log_index %}
+
+        {% if log.context.errorCount is defined %}
+            <span class="text-small text-bold">({{ log.context.errorCount }} times)</span>
+        {% endif %}
+
+        {% if stack %}
+            <button class="btn-link text-small sf-toggle" data-toggle-selector="#{{ id }}" data-toggle-alt-content="Hide stack trace">Show stack trace</button>
+        {% endif %}
+
+        {% for index, call in stack if index > 1 %}
+            {% if index == 2 %}
+                <ul class="sf-call-stack hidden" id="{{ id }}">
+            {% endif %}
+
+            {% if call.class is defined %}
+                {% set from = call.class|abbr_class ~ '::' ~ call.function|abbr_method() %}
+            {% elseif call.function is defined %}
+                {% set from = call.function|abbr_method %}
+            {% elseif call.file is defined %}
+                {% set from = call.file %}
+            {% else %}
+                {% set from = '-' %}
+            {% endif %}
+
+            {% set file_name = (call.file is defined and call.line is defined) ? call.file|replace({'\\': '/'})|split('/')|last %}
+
+            <li>
+                {{ from|raw }}
+                {% if file_name %}
+                    <span class="text-small">(called from {{ call.file|format_file(call.line, file_name)|raw }})</span>
+                {% endif %}
+            </li>
+
+            {% if index == stack|length - 1 %}
+                </ul>
+            {% endif %}
+        {% endfor %}
+    {% else %}
+        {% if log.context is defined and log.context is not empty %}
+            <span class="metadata">
+                <strong>Context</strong>: {{ log.context|json_encode(64 b-or 256)|replace({
+                    '{"' : '{ "', '"}' : '" }', '":{' : '": {', '":"' : '": "', '","' : '", "'
+                }) }}
+            </span>
+        {% endif %}
+    {% endif %}
+{% endmacro %}

--- a/tests/Goetas/Twital/Tests/templates/web_profiler_js.html.twig
+++ b/tests/Goetas/Twital/Tests/templates/web_profiler_js.html.twig
@@ -1,0 +1,433 @@
+<script>/*<![CDATA[*/
+    {# Caution: the contents of this file are processed by Twig before loading
+                them as JavaScript source code. Always use '/*' comments instead
+                of '//' comments to avoid impossible-to-debug side-effects #}
+
+    Sfjs = (function() {
+        "use strict";
+
+        var classListIsSupported = 'classList' in document.documentElement;
+
+        if (classListIsSupported) {
+            var hasClass = function (el, cssClass) { return el.classList.contains(cssClass); };
+            var removeClass = function(el, cssClass) { el.classList.remove(cssClass); };
+            var addClass = function(el, cssClass) { el.classList.add(cssClass); };
+            var toggleClass = function(el, cssClass) { el.classList.toggle(cssClass); };
+        } else {
+            var hasClass = function (el, cssClass) { return el.className.match(new RegExp('\\b' + cssClass + '\\b')); };
+            var removeClass = function(el, cssClass) { el.className = el.className.replace(new RegExp('\\b' + cssClass + '\\b'), ' '); };
+            var addClass = function(el, cssClass) { if (!hasClass(el, cssClass)) { el.className += " " + cssClass; } };
+            var toggleClass = function(el, cssClass) { hasClass(el, cssClass) ? removeClass(el, cssClass) : addClass(el, cssClass); };
+        }
+
+        var noop = function() {},
+
+            collectionToArray = function (collection) {
+                var length = collection.length || 0,
+                    results = new Array(length);
+
+                while (length--) {
+                    results[length] = collection[length];
+                }
+
+                return results;
+            },
+
+            profilerStorageKey = 'sf2/profiler/',
+
+            request = function(url, onSuccess, onError, payload, options) {
+                var xhr = window.XMLHttpRequest ? new XMLHttpRequest() : new ActiveXObject('Microsoft.XMLHTTP');
+                options = options || {};
+                options.maxTries = options.maxTries || 0;
+                xhr.open(options.method || 'GET', url, true);
+                xhr.setRequestHeader('X-Requested-With', 'XMLHttpRequest');
+                xhr.onreadystatechange = function(state) {
+                    if (4 !== xhr.readyState) {
+                        return null;
+                    }
+
+                    if (xhr.status == 404 && options.maxTries > 1) {
+                        setTimeout(function(){
+                            options.maxTries--;
+                            request(url, onSuccess, onError, payload, options);
+                        }, 500);
+
+                        return null;
+                    }
+
+                    if (200 === xhr.status) {
+                        (onSuccess || noop)(xhr);
+                    } else {
+                        (onError || noop)(xhr);
+                    }
+                };
+                xhr.send(payload || '');
+            },
+
+            getPreference = function(name) {
+                if (!window.localStorage) {
+                    return null;
+                }
+
+                return localStorage.getItem(profilerStorageKey + name);
+            },
+
+            setPreference = function(name, value) {
+                if (!window.localStorage) {
+                    return null;
+                }
+
+                localStorage.setItem(profilerStorageKey + name, value);
+            },
+
+            requestStack = [],
+
+            renderAjaxRequests = function() {
+                var requestCounter = document.querySelectorAll('.sf-toolbar-ajax-requests');
+                if (!requestCounter.length) {
+                    return;
+                }
+
+                var ajaxToolbarPanel = document.querySelector('.sf-toolbar-block-ajax');
+                var tbodies = document.querySelectorAll('.sf-toolbar-ajax-request-list');
+                var state = 'ok';
+                if (tbodies.length) {
+                    var tbody = tbodies[0];
+
+                    var rows = document.createDocumentFragment();
+
+                    if (requestStack.length) {
+                        for (var i = 0; i < requestStack.length; i++) {
+                            var request = requestStack[i];
+
+                            var row = document.createElement('tr');
+                            rows.appendChild(row);
+
+                            var methodCell = document.createElement('td');
+                            if (request.error) {
+                                methodCell.className = 'sf-ajax-request-error';
+                            }
+                            methodCell.textContent = request.method;
+                            row.appendChild(methodCell);
+
+                            var pathCell = document.createElement('td');
+                            pathCell.className = 'sf-ajax-request-url';
+                            if ('GET' === request.method) {
+                                var pathLink = document.createElement('a');
+                                pathLink.setAttribute('href', request.url);
+                                pathLink.textContent = request.url;
+                                pathCell.appendChild(pathLink);
+                            } else {
+                                pathCell.textContent = request.url;
+                            }
+                            pathCell.setAttribute('title', request.url);
+                            row.appendChild(pathCell);
+
+                            var durationCell = document.createElement('td');
+                            durationCell.className = 'sf-ajax-request-duration';
+
+                            if (request.duration) {
+                                durationCell.textContent = request.duration + "ms";
+                            } else {
+                                durationCell.textContent = '-';
+                            }
+                            row.appendChild(durationCell);
+
+                            row.appendChild(document.createTextNode(' '));
+                            var profilerCell = document.createElement('td');
+
+                            if (request.profilerUrl) {
+                                var profilerLink = document.createElement('a');
+                                profilerLink.setAttribute('href', request.profilerUrl);
+                                profilerLink.textContent = request.profile;
+                                profilerCell.appendChild(profilerLink);
+                            } else {
+                                profilerCell.textContent = 'n/a';
+                            }
+
+                            row.appendChild(profilerCell);
+
+                            var requestState = 'ok';
+                            if (request.error) {
+                                requestState = 'error';
+                                if (state != "loading" && i > requestStack.length - 4) {
+                                    state = 'error';
+                                }
+                            } else if (request.loading) {
+                                requestState = 'loading';
+                                state = 'loading';
+                            }
+                            row.className = 'sf-ajax-request sf-ajax-request-' + requestState;
+                        }
+
+                        var infoSpan = document.querySelectorAll(".sf-toolbar-ajax-info")[0];
+                        var children = collectionToArray(tbody.children);
+                        for (var i = 0; i < children.length; i++) {
+                            tbody.removeChild(children[i]);
+                        }
+                        tbody.appendChild(rows);
+
+                        if (infoSpan) {
+                            var text = requestStack.length + ' AJAX request' + (requestStack.length > 1 ? 's' : '');
+                            infoSpan.textContent = text;
+                        }
+
+                        ajaxToolbarPanel.style.display = 'block';
+                    } else {
+                        ajaxToolbarPanel.style.display = 'none';
+                    }
+                }
+
+                requestCounter[0].textContent = requestStack.length;
+
+                var className = 'sf-toolbar-ajax-requests sf-toolbar-value';
+                requestCounter[0].className = className;
+
+                if (state == 'ok') {
+                    Sfjs.removeClass(ajaxToolbarPanel, 'sf-ajax-request-loading');
+                    Sfjs.removeClass(ajaxToolbarPanel, 'sf-toolbar-status-red');
+                } else if (state == 'error') {
+                    Sfjs.addClass(ajaxToolbarPanel, 'sf-toolbar-status-red');
+                } else {
+                    Sfjs.addClass(ajaxToolbarPanel, 'sf-ajax-request-loading');
+                }
+            };
+
+        var addEventListener;
+
+        var el = document.createElement('div');
+        if (!'addEventListener' in el) {
+            addEventListener = function (element, eventName, callback) {
+                element.attachEvent('on' + eventName, callback);
+            };
+        } else {
+            addEventListener = function (element, eventName, callback) {
+                element.addEventListener(eventName, callback, false);
+            };
+        }
+
+        {% if excluded_ajax_paths is defined %}
+            if (window.XMLHttpRequest && XMLHttpRequest.prototype.addEventListener) {
+                var proxied = XMLHttpRequest.prototype.open;
+
+                XMLHttpRequest.prototype.open = function(method, url, async, user, pass) {
+                    var self = this;
+
+                    /* prevent logging AJAX calls to static and inline files, like templates */
+                    var path = url;
+                    if (url.substr(0, 1) === '/') {
+                        if (0 === url.indexOf('{{ request.basePath|e('js') }}')) {
+                            path = url.substr({{ request.basePath|length }});
+                        }
+                    }
+                    else if (0 === url.indexOf('{{ (request.schemeAndHttpHost ~ request.basePath)|e('js') }}')) {
+                        path = url.substr({{ (request.schemeAndHttpHost ~ request.basePath)|length }});
+                    }
+
+                    if (path.substr(0, 1) === '/' && !path.match(new RegExp({{ excluded_ajax_paths|json_encode|raw }}))) {
+                        var stackElement = {
+                            loading: true,
+                            error: false,
+                            url: url,
+                            method: method,
+                            start: new Date()
+                        };
+
+                        requestStack.push(stackElement);
+
+                        this.addEventListener('readystatechange', function() {
+                            if (self.readyState == 4) {
+                                stackElement.duration = new Date() - stackElement.start;
+                                stackElement.loading = false;
+                                stackElement.error = self.status < 200 || self.status >= 400;
+                                stackElement.profile = self.getResponseHeader("X-Debug-Token");
+                                stackElement.profilerUrl = self.getResponseHeader("X-Debug-Token-Link");
+
+                                Sfjs.renderAjaxRequests();
+                            }
+                        }, false);
+
+                        Sfjs.renderAjaxRequests();
+                    }
+
+                    proxied.apply(this, Array.prototype.slice.call(arguments));
+                };
+            }
+        {% endif %}
+
+        return {
+            hasClass: hasClass,
+
+            removeClass: removeClass,
+
+            addClass: addClass,
+
+            toggleClass: toggleClass,
+
+            getPreference: getPreference,
+
+            setPreference: setPreference,
+
+            addEventListener: addEventListener,
+
+            request: request,
+
+            renderAjaxRequests: renderAjaxRequests,
+
+            load: function(selector, url, onSuccess, onError, options) {
+                var el = document.getElementById(selector);
+
+                if (el && el.getAttribute('data-sfurl') !== url) {
+                    request(
+                        url,
+                        function(xhr) {
+                            el.innerHTML = xhr.responseText;
+                            el.setAttribute('data-sfurl', url);
+                            removeClass(el, 'loading');
+                            (onSuccess || noop)(xhr, el);
+                        },
+                        function(xhr) { (onError || noop)(xhr, el); },
+                        '',
+                        options
+                    );
+                }
+
+                return this;
+            },
+
+            toggle: function(selector, elOn, elOff) {
+                var tmp = elOn.style.display,
+                    el = document.getElementById(selector);
+
+                elOn.style.display = elOff.style.display;
+                elOff.style.display = tmp;
+
+                if (el) {
+                    el.style.display = 'none' === tmp ? 'none' : 'block';
+                }
+
+                return this;
+            },
+
+            createTabs: function() {
+                var tabGroups = document.querySelectorAll('.sf-tabs');
+
+                /* create the tab navigation for each group of tabs */
+                for (var i = 0; i < tabGroups.length; i++) {
+                    var tabs = tabGroups[i].querySelectorAll('.tab');
+                    var tabNavigation = document.createElement('ul');
+                    tabNavigation.className = 'tab-navigation';
+
+                    for (var j = 0; j < tabs.length; j++) {
+                        var tabId = 'tab-' + i + '-' + j;
+                        var tabTitle = tabs[j].querySelector('.tab-title').innerHTML;
+
+                        var tabNavigationItem = document.createElement('li');
+                        tabNavigationItem.setAttribute('data-tab-id', tabId);
+                        if (j == 0) { Sfjs.addClass(tabNavigationItem, 'active'); }
+                        if (Sfjs.hasClass(tabs[j], 'disabled')) { Sfjs.addClass(tabNavigationItem, 'disabled'); }
+                        tabNavigationItem.innerHTML = tabTitle;
+                        tabNavigation.appendChild(tabNavigationItem);
+
+                        var tabContent = tabs[j].querySelector('.tab-content');
+                        tabContent.parentElement.setAttribute('id', tabId);
+                    }
+
+                    tabGroups[i].insertBefore(tabNavigation, tabGroups[i].firstChild);
+                }
+
+                /* display the active tab and add the 'click' event listeners */
+                for (i = 0; i < tabGroups.length; i++) {
+                    tabNavigation = tabGroups[i].querySelectorAll('.tab-navigation li');
+
+                    for (j = 0; j < tabNavigation.length; j++) {
+                        tabId = tabNavigation[j].getAttribute('data-tab-id');
+                        document.getElementById(tabId).querySelector('.tab-title').className = 'hidden';
+
+                        if (Sfjs.hasClass(tabNavigation[j], 'active')) {
+                            document.getElementById(tabId).className = 'block';
+                        } else {
+                            document.getElementById(tabId).className = 'hidden';
+                        }
+
+                        tabNavigation[j].addEventListener('click', function(e) {
+                            var activeTab = e.target || e.srcElement;
+
+                            /* needed because when the tab contains HTML contents, user can click */
+                            /* on any of those elements instead of their parent '<li>' element */
+                            while (activeTab.tagName.toLowerCase() !== 'li') {
+                                activeTab = activeTab.parentNode;
+                            }
+
+                            /* get the full list of tabs through the parent of the active tab element */
+                            var tabNavigation = activeTab.parentNode.children;
+                            for (var k = 0; k < tabNavigation.length; k++) {
+                                var tabId = tabNavigation[k].getAttribute('data-tab-id');
+                                document.getElementById(tabId).className = 'hidden';
+                                Sfjs.removeClass(tabNavigation[k], 'active');
+                            }
+
+                            Sfjs.addClass(activeTab, 'active');
+                            var activeTabId = activeTab.getAttribute('data-tab-id');
+                            document.getElementById(activeTabId).className = 'block';
+                        });
+                    }
+                }
+            },
+
+            createToggles: function() {
+                var toggles = document.querySelectorAll('.sf-toggle');
+
+                for (var i = 0; i < toggles.length; i++) {
+                    var elementSelector = toggles[i].getAttribute('data-toggle-selector');
+                    var element = document.querySelector(elementSelector);
+
+                    Sfjs.addClass(element, 'sf-toggle-content');
+
+                    if (toggles[i].hasAttribute('data-toggle-initial') && toggles[i].getAttribute('data-toggle-initial') == 'display') {
+                        Sfjs.addClass(element, 'sf-toggle-visible');
+                    } else {
+                        Sfjs.addClass(element, 'sf-toggle-hidden');
+                    }
+
+                    Sfjs.addEventListener(toggles[i], 'click', function(e) {
+                        e.preventDefault();
+
+                        var toggle = e.target || e.srcElement;
+
+                        /* needed because when the toggle contains HTML contents, user can click */
+                        /* on any of those elements instead of their parent '.sf-toggle' element */
+                        while (!Sfjs.hasClass(toggle, 'sf-toggle')) {
+                            toggle = toggle.parentNode;
+                        }
+
+                        var element = document.querySelector(toggle.getAttribute('data-toggle-selector'));
+
+                        Sfjs.toggleClass(element, 'sf-toggle-hidden');
+                        Sfjs.toggleClass(element, 'sf-toggle-visible');
+
+                        /* the toggle doesn't change its contents when clicking on it */
+                        if (!toggle.hasAttribute('data-toggle-alt-content')) {
+                            return;
+                        }
+
+                        if (!toggle.hasAttribute('data-toggle-original-content')) {
+                            toggle.setAttribute('data-toggle-original-content', toggle.innerHTML);
+                        }
+
+                        var currentContent = toggle.innerHTML;
+                        var originalContent = toggle.getAttribute('data-toggle-original-content');
+                        var altContent = toggle.getAttribute('data-toggle-alt-content');
+                        toggle.innerHTML = currentContent !== altContent ? altContent : originalContent;
+                    });
+                }
+            }
+        };
+    })();
+
+    Sfjs.addEventListener(window, 'load', function() {
+        Sfjs.createTabs();
+        Sfjs.createToggles();
+    });
+
+/*]]>*/</script>

--- a/tests/Goetas/Twital/Tests/templates/widget-header.twig
+++ b/tests/Goetas/Twital/Tests/templates/widget-header.twig
@@ -1,0 +1,36 @@
+{% extends '@widget/widget.html.twig' %}
+
+{% from '@widget/semantic-ui/macros.html.twig' import size %}
+
+{% block widget %}
+    {%- set align = (centered|default or center|default) ? 'center' : align|default -%}
+    {%- set align = left|default ? 'left' : (right|default ? 'right' : align) -%}
+
+{% set tag = 'h'~level %}
+<{{ tag }} class="ui header
+    {%- if 'icon' is block name %} icon{% endif -%}
+    {%- if disabled|default %} disabled{% endif -%}
+    {%- if dividing|default %} dividing{% endif -%}
+    {%- if block|default %} block{% endif -%}
+    {%- if attached|default %} {{ attached }} attached{% endif -%}
+    {%- if floated|default %} {{ floated }} floated{% endif -%}
+    {%- if align|default %} {{ align }} aligned{% endif -%}
+    {%- if color|default %} {{ color }}{% endif -%}
+    {%- if inverted|default %} inverted{% endif -%}
+    {%- if size|default %} {{ size(size) }}{% endif -%}
+">
+    {{ block('icon') }}
+    {% if 'icon' is block name or 'subheader' is block name %}
+        <div class="content">
+            {{ block('header') }}
+            {% if 'subheader' is block name %}<div class="sub header">{{ block('subheader') }}</div>{% endif %}
+        </div>
+    {% else %}
+        {{ block('header') }}
+    {% endif %}
+</{{ tag }}>
+{% endblock %}
+
+{% block header %}
+    {{ 'text' is block name ? block('text') : block('__content__') }}
+{% endblock %}


### PR DESCRIPTION
Preserve a full compatibility of Twig templates for XHTML and XML adapters is too complicated. The old code causes an error for some templates, e.g. [PREG_BACKTRACK_LIMIT_ERROR](http://php.net/manual/en/function.preg-last-error.php).