### PR TITLE
Failing test in attribute 

### DIFF
--- a/tests/Tests/DynamicAttrAttributeTest.php
+++ b/tests/Tests/DynamicAttrAttributeTest.php
@@ -39,6 +39,7 @@ class DynamicAttrAttributeTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array('<div t:attr="class=\'foo\'">content</div>', '<div class="foo">content</div>'),
+            array('<div><img src="{{ \'abc\'}}"/></div>', '<div><img src="abc"/></div>'),
             array('<div class="bar" t:attr="class=false">content</div>', '<div>content</div>'),
             array('<div class="bar" t:attr="class=\'foo\'">content</div>', '<div class="foo">content</div>'),
             array('<div t:attr="condition?class=\'foo\'">content</div>', '<div class="foo">content</div>', array('condition'=>1)),


### PR DESCRIPTION
```html
<!-- working -->
<img src="{{ 'abc' }}"/>

<!-- infinite loop in AbstractTwigExpressionSubscriber line 46 -->
<img src="{{ 'abc'}}"/>

<!-- the only difference is the whitespace  at the end of the twig expression -->
```

at https://github.com/goetas/twital/blob/master/src/EventSubscriber/AbstractTwigExpressionSubscriber.php#L46 there is an infinite loop. 

`$inners[0][0]`  is always an empty string, so offset does not go forward...

@hason any idea?

(related issue https://github.com/goetas/twital/issues/48)